### PR TITLE
Add nix flake

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ srcs := $(shell find src/ -type f -iname "*.cpp")
 objs := $(srcs:src/%.cpp=obj/%.o)
 deps := $(objs:%.o=%.d)
 
-CXXFLAGS := -O3 -flto=auto -fPIC -m32 -std=c++20 -Wall -Wextra -Wpedantic
+CXXFLAGS := -O3 -flto=auto -fPIC -m32 -std=c++20 -Wall -Wextra -Wpedantic -Wno-error=format-security
 
 LDFLAGS := -shared
 LDFLAGS += $(shell pkg-config --libs "openssl")

--- a/README.md
+++ b/README.md
@@ -42,6 +42,27 @@ Configuration gets created at ~/.config/SLSsteam/config.yaml during first run
 ./setup.sh uninstall
 ```
 
+## NixOS
+Add this to your flake inputs
+```nix
+sls-steam = {
+  url = "github:AceSLS/SLSsteam";
+  inputs.nixpkgs.follows = "nixpkgs";
+};
+```
+Then, add it to your packages and run it with `SLSsteam` from the terminal
+```nix
+environment.systemPackages = [inputs.sls-steam.packages.${pkgs.system}.wrapped];
+```
+Alternatively, to have it run with steam on any launch, add it to your steam environment variables
+```nix
+programs.steam.package = pkgs.steam.override {
+  extraEnv = {
+    LD_AUDIT = "${inputs.sls-steam.packages.${pkgs.system}.sls-steam}/SLSsteam.so";
+  };
+};
+```
+
 ## Updating
 
 ```bash

--- a/default.nix
+++ b/default.nix
@@ -10,8 +10,8 @@ pkgs.pkgsi686Linux.stdenv.mkDerivation {
   src = ./.;
 
   nativeBuildInputs = with pkgs; [
-    pkgsi686Linux.pkg-config
-    pkgsi686Linux.makeWrapper
+    pkg-config
+    makeWrapper
   ];
 
   buildInputs = with pkgs.pkgsi686Linux; [
@@ -25,8 +25,7 @@ pkgs.pkgsi686Linux.stdenv.mkDerivation {
   '';
 
   installPhase = ''
-    mkdir -p $out/bin/
-    mkdir -p $out
+    mkdir -p $out/
     cp bin/SLSsteam.so $out/
   '';
 

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,39 @@
+{
+  rev,
+  lib,
+  stdenv,
+  pkgs,
+}:
+pkgs.pkgsi686Linux.stdenv.mkDerivation {
+  pname = "SLSsteam";
+  version = "${rev}";
+  src = ./.;
+
+  nativeBuildInputs = with pkgs; [
+    pkgsi686Linux.pkg-config
+    pkgsi686Linux.makeWrapper
+  ];
+
+  buildInputs = with pkgs.pkgsi686Linux; [
+    openssl
+    which
+  ];
+
+  buildPhase = ''
+    make clean
+    make
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin/
+    mkdir -p $out
+    cp bin/SLSsteam.so $out/
+  '';
+
+  meta = {
+    description = "Steamclient Modification for Linux";
+    homepage = "https://github.com/AceSLS/SLSsteam";
+    license = lib.licenses.agpl3Only;
+    platforms = lib.platforms.linux;
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1754214453,
+        "narHash": "sha256-Q/I2xJn/j1wpkGhWkQnm20nShYnG7TI99foDBpXm1SY=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "5b09dc45f24cf32316283e62aec81ffee3c3e376",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,30 @@
+{
+  description = "SLSsteam";
+
+  inputs.nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+
+  outputs = {
+    self,
+    nixpkgs,
+  }: let
+    forAllSystems = fn:
+      nixpkgs.lib.genAttrs nixpkgs.lib.platforms.linux (
+        system: let
+          pkgs = import nixpkgs {
+            inherit system;
+            config.allowUnfreePredicate = pkg:
+              builtins.elem (nixpkgs.lib.getName pkg) ["steam" "steam-unwrapped"];
+          };
+        in
+          fn pkgs
+      );
+  in {
+    formatter = forAllSystems (pkgs: pkgs.alejandra);
+
+    packages = forAllSystems (pkgs: rec {
+      sls-steam = pkgs.callPackage ./default.nix {rev = self.rev or self.dirtyRev or "unknown";};
+      wrapped = pkgs.callPackage ./wrapped.nix {rev = self.rev or self.dirtyRev or "unknown";};
+      default = sls-steam;
+    });
+  };
+}

--- a/wrapped.nix
+++ b/wrapped.nix
@@ -1,0 +1,29 @@
+{
+  pkgs,
+  lib,
+  rev,
+  callPackage,
+}: let
+  sls-steam = callPackage ./default.nix {
+    inherit rev;
+  };
+in
+  pkgs.stdenv.mkDerivation {
+    pname = "SLSsteam-wrapper";
+    version = rev;
+
+    src = sls-steam;
+
+    nativeBuildInputs = [pkgs.makeWrapper];
+
+    installPhase = ''
+      mkdir -p $out/bin
+      makeWrapper ${pkgs.steam}/bin/steam $out/bin/SLSsteam \
+        --set LD_AUDIT "${sls-steam}/SLSsteam.so"
+    '';
+
+    meta = {
+      description = "Steamclient Modification for Linux";
+      platforms = lib.platforms.linux;
+    };
+  }


### PR DESCRIPTION
I've added a nix flake to the repo for usage in NixOS.
This would close #11.

Also included instructions on how to use it in the readme, it should be plug and play.
If any issues arise let me know, it's my first time making a derivation, but so far everything seems to work.

Tested on x86_64-linux with nixpkgs 25.05