### PR TITLE
Fix UserSubscribedAppInTicket pattern

### DIFF
--- a/src/hooks.cpp
+++ b/src/hooks.cpp
@@ -435,9 +435,9 @@ static bool hkClientUser_BIsSubscribedApp(void* pClientUser, uint32_t appId)
 static uint8_t hkClientUser_IsUserSubscribedAppInTicket(void* pClientUser, uint32_t steamId, uint32_t a2, uint32_t a3, uint32_t appId)
 {
 	const char ticketState = Hooks::IClientUser_IsUserSubscribedAppInTicket.tramp.fn(pClientUser, steamId, a2, a3, appId);
-	g_pLog->once("IClientUser::IsUserSubscribedInAppTicket(%p, %u, %u, %u, %u) -> %i\n", pClientUser, steamId, a2, a3, appId, ticketState);
+	g_pLog->once("IClientUser::IsUserSubscribedAppInTicket(%p, %u, %u, %u, %u) -> %i\n", pClientUser, steamId, a2, a3, appId, ticketState);
 	//Don't log the steamId, protect users from themselves and stuff
-	//g_pLog->once("IClientUser::IsUserSubscribedInAppTicket(%p, %u, %u, %u) -> %i\n", pClientUser, a2, a3, appId, subscribed);
+	//g_pLog->once("IClientUser::IsUserSubscribedAppInTicket(%p, %u, %u, %u) -> %i\n", pClientUser, a2, a3, appId, subscribed);
 
 	//Might want to compare the steamId param to the g_currentSteamId in the future
 	//Although not doing that might also work for Dedicated servers?
@@ -665,7 +665,7 @@ bool Hooks::setup()
 		CheckAppOwnership.setup(Patterns::CheckAppOwnership, MemHlp::SigFollowMode::Relative, &hkCheckAppOwnership)
 		&& LogSteamPipeCall.setup(Patterns::LogSteamPipeCall, MemHlp::SigFollowMode::Relative, &hkLogSteamPipeCall)
 		&& IClientUser_BIsSubscribedApp.setup(Patterns::IsSubscribedApp, MemHlp::SigFollowMode::Relative, &hkClientUser_BIsSubscribedApp)
-		&& IClientUser_IsUserSubscribedAppInTicket.setup(Patterns::IsUserSubscribedInAppTicket, MemHlp::SigFollowMode::Relative, &hkClientUser_IsUserSubscribedAppInTicket)
+		&& IClientUser_IsUserSubscribedAppInTicket.setup(Patterns::IsUserSubscribedAppInTicket, MemHlp::SigFollowMode::Relative, &hkClientUser_IsUserSubscribedAppInTicket)
 		&& IClientUser_GetSubscribedApps.setup(Patterns::GetSubscribedApps, MemHlp::SigFollowMode::Relative, &hkClientUser_GetSubscribedApps)
 
 		&& runningApp != LM_ADDRESS_BAD

--- a/src/patterns.hpp
+++ b/src/patterns.hpp
@@ -27,7 +27,7 @@ namespace Patterns
 	//Relative
 	constexpr lm_string_t GetSubscribedApps = "E8 ? ? ? ? 89 C6 83 C4 10 85 C0 0F 84 ? ? ? ? 8B 9D ? ? ? ? 39 D8";
 	//Relative
-	constexpr lm_string_t IsUserSubscribedInAppTicket = "E8 ? ? ? ? 89 C3 83 C4 20 8B ? ? ? ? ? 8B";
+	constexpr lm_string_t IsUserSubscribedAppInTicket = "E8 ? ? ? ? 89 C3 83 C4 20 8B ? ? ? ? ? 8B";
 	//Relative
 	constexpr lm_string_t IsSubscribedApp = "E8 ? ? ? ? 83 C4 10 84 C0 74 ? 8B 95 ? ? ? ? 83 EC 04";
 	//End of function

--- a/src/patterns.hpp
+++ b/src/patterns.hpp
@@ -26,8 +26,8 @@ namespace Patterns
 	constexpr lm_string_t IClientUser_PipeLoop = "E8 ? ? ? ? 83 C4 10 E9 ? ? ? ? E8 ? ? ? ? FF 75";
 	//Relative
 	constexpr lm_string_t GetSubscribedApps = "E8 ? ? ? ? 89 C6 83 C4 10 85 C0 0F 84 ? ? ? ? 8B 9D ? ? ? ? 39 D8";
-	//Relative, inside the VFT func
-	constexpr lm_string_t IsUserSubscribedInAppTicket = "E8 ? ? ? ? 83 C4 38 5B C3 ? ? ? ? ? ? ? 8D 83";
+	//Relative
+	constexpr lm_string_t IsUserSubscribedInAppTicket = "E8 ? ? ? ? 89 C3 83 C4 20 8B ? ? ? ? ? 8B";
 	//Relative
 	constexpr lm_string_t IsSubscribedApp = "E8 ? ? ? ? 83 C4 10 84 C0 74 ? 8B 95 ? ? ? ? 83 EC 04";
 	//End of function


### PR DESCRIPTION
The pattern for UserSubscribedAppInTicket does currently not work in the beta branch of steam.
I replaced it with a pattern which works in both stable and beta.

I also renamed it from UserSubscribed**In**AppTicket to UserSubscribedApp**In**Ticket, which seems to be a leftover typo in the pattern variable and log messages :blush:.