### PR TITLE
Add Flatpak install support

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -7,7 +7,7 @@ SLSAUDIT="LD_AUDIT=\"$SLSDIR/library-inject.so:$SLSDIR/SLSsteam.so\""
 
 FLATPAK_APP_ID="com.valvesoftware.Steam"
 FLATPAK_SLSDIR="$HOME/.var/app/$FLATPAK_APP_ID/.local/share/SLSsteam"
-FLATPAK_SLSLIB="$FLATPAK_SLSDIR/SLSsteam.so"
+FLATPAK_LD_AUDIT="/app/links/\$LIB/libshared-library-guard.so:$FLATPAK_SLSDIR/library-inject.so:$FLATPAK_SLSDIR/SLSsteam.so"
 
 uninstall()
 {
@@ -135,8 +135,7 @@ install_slssteam()
 
 install_flatpak()
 {
-	LIB="./bin/SLSsteam.so"
-	if [ ! -f "$LIB" ]; then
+	if [ ! -f "./bin/SLSsteam.so" ]; then
 		echo "bin/SLSsteam.so not found! Did you run the install.sh in the correct directory?"
 		return 1
 	fi
@@ -159,9 +158,9 @@ install_flatpak()
 		fi
 	fi
 
-	cp -v "$LIB" "$FLATPAK_SLSDIR/"
+	cp -v ./bin/* "$FLATPAK_SLSDIR/"
 
-	flatpak override --user --env=LD_AUDIT="/app/links/\$LIB/libshared-library-guard.so:$FLATPAK_SLSLIB" --env=SHARED_LIBRARY_GUARD=0 "$FLATPAK_APP_ID"
+	flatpak override --user --env=LD_AUDIT="$FLATPAK_LD_AUDIT" --env=SHARED_LIBRARY_GUARD=0 "$FLATPAK_APP_ID"
 
 	echo "Flatpak install done!"
 }


### PR DESCRIPTION
Steam Flatpak's `steam_wrapper.py` has this code that overwrites direct `LD_AUDIT`:
```python
def configure_shared_library_guard():
    mode = int(os.environ.get("SHARED_LIBRARY_GUARD", 1))
    if not mode:
        return
    else:
        os.environ["LD_AUDIT"] = f"/app/links/$LIB/libshared-library-guard.so"
```

We can disable that and put both paths ourselves and that seems to work.

Wiki updates:
Config location
```
For Flatpak installations, the configuration file is located at `~/.var/app/com.valvesoftware.Steam/config/SLSsteam/config.yaml`.
```
Installation
```
# Flatpak

Pre requisites:
- Steam Flatpak installed (`com.valvesoftware.Steam`)

Installation:
- Get latest SLSsteam-Any.7z from [releases](https://github.com/AceSLS/SLSsteam/releases).
- Extract it somewhere, go into the newly created SLSsteam directory and open a terminal there.
- Run ```./setup.sh flatpak-install``` to install SLSsteam.

Uninstallation:
- Run ```./setup.sh flatpak-uninstall``` to remove SLSsteam.

Running:
Open Steam Flatpak as usual.
```

Closes #14