### PR TITLE
Fix Steam Input with FakeAppIds

### DIFF
--- a/src/hooks.hpp
+++ b/src/hooks.hpp
@@ -148,6 +148,12 @@ namespace Hooks
 
 	extern lm_address_t IClientUser_GetSteamId;
 
+	typedef void(*ControllerConfig_AddToConfigCacheHandler_t)(void*, int, int, void*, void*);
+	typedef void(*ControllerConfig_QueueControllerActivation_t)(void*, int, int, int, int, int);
+
+	extern DetourHook<ControllerConfig_AddToConfigCacheHandler_t> ControllerConfig_AddToConfigCacheHandler;
+	extern DetourHook<ControllerConfig_QueueControllerActivation_t> ControllerConfig_QueueControllerActivation;
+
 	bool setup();
 	void place();
 	void remove();

--- a/src/patterns.cpp
+++ b/src/patterns.cpp
@@ -284,6 +284,22 @@ namespace Patterns
 		};
 	}
 
+	namespace ControllerConfig
+	{
+		Pattern_t AddToConfigCacheHandler
+		{
+			"ControllerConfig::AddToConfigCacheHandler",
+			"55 57 56 53 E8 ? ? ? ? 81 C3 ? ? ? ? 83 EC 4C 8B 44 24 6C 8B 54 24 78 8B 74 24 60",
+			SigFollowMode::None
+		};
+		Pattern_t QueueControllerActivation
+		{
+			"ControllerConfig::QueueControllerActivation",
+			"55 57 56 53 E8 ? ? ? ? 81 C3 ? ? ? ? 83 EC 7C 8B 84 24 9C 00 00 00",
+			SigFollowMode::None
+		};
+	}
+
 	std::vector<Pattern_t*> patterns;
 }
 

--- a/src/patterns.hpp
+++ b/src/patterns.hpp
@@ -99,6 +99,13 @@ namespace Patterns
 		extern Pattern_t PipeLoop;
 	}
 
+	//Controller config IPC handlers - intercept AppId from game process
+	namespace ControllerConfig
+	{
+		extern Pattern_t AddToConfigCacheHandler;
+		extern Pattern_t QueueControllerActivation;
+	}
+
 	namespace IClientUtils
 	{
 		extern Pattern_t PipeLoop;


### PR DESCRIPTION
Controller/gamepad support breaks when using FakeAppIds because the game process sends its real AppId via IPC, overriding our spoof before the controller subsystem sees it.

This hooks the IPC receiver functions (`AddToConfigCacheHandler` and `QueueControllerActivation`) to spoof the AppId when the game registers with Steam.

Tested working with Elden Ring Nightreign and BLEACH Rebirth of Souls.