### PR TITLE
NixOS Fixes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1754214453,
-        "narHash": "sha256-Q/I2xJn/j1wpkGhWkQnm20nShYnG7TI99foDBpXm1SY=",
+        "lastModified": 1769170682,
+        "narHash": "sha256-oMmN1lVQU0F0W2k6OI3bgdzp2YOHWYUAw79qzDSjenU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5b09dc45f24cf32316283e62aec81ffee3c3e376",
+        "rev": "c5296fdd05cfa2c187990dd909864da9658df755",
         "type": "github"
       },
       "original": {

--- a/nix-modules/default.nix
+++ b/nix-modules/default.nix
@@ -3,36 +3,55 @@
   lib,
   stdenv,
   pkgs,
-}:
-pkgs.pkgsi686Linux.stdenv.mkDerivation {
-  pname = "SLSsteam";
-  version = "${rev}";
-  src = ../.;
-
-  nativeBuildInputs = with pkgs; [
-    pkg-config
-    makeWrapper
-  ];
-
-  buildInputs = with pkgs.pkgsi686Linux; [
-    openssl
-    which
-  ];
-
-  buildPhase = ''
-    make clean
-    make
-  '';
-
-  installPhase = ''
-    mkdir -p $out/
-    cp bin/SLSsteam.so $out/
-  '';
-
-  meta = {
-    description = "Steamclient Modification for Linux";
-    homepage = "https://github.com/AceSLS/SLSsteam";
-    license = lib.licenses.agpl3Only;
-    platforms = lib.platforms.linux;
+  buildDotnetModule,
+  dotnetCorePackages,
+}: let
+  ticketGrabber = import ./ticket-grabber.nix {
+    inherit rev buildDotnetModule dotnetCorePackages;
   };
-}
+in
+  pkgs.pkgsi686Linux.stdenv.mkDerivation {
+    pname = "SLSsteam";
+    version = "${rev}";
+    src = ../.;
+
+    nativeBuildInputs = with pkgs; [
+      pkg-config
+      makeWrapper
+    ];
+
+    buildInputs = with pkgs.pkgsi686Linux; [
+      openssl
+      which
+      curl
+    ];
+
+    buildPhase = ''
+      make clean
+
+      mkdir -p tools/ticket-grabber/bin/Release/net9.0/linux-x64/publish
+      cp ${ticketGrabber}/bin/ticket-grabber \
+       tools/ticket-grabber/bin/Release/net9.0/linux-x64/publish/ticket-grabber
+
+      make
+    '';
+
+    installPhase = ''
+      mkdir -p $out/
+      cp bin/SLSsteam.so $out/
+      cp bin/library-inject.so $out/
+
+      patchelf --set-rpath ${
+        lib.makeLibraryPath [
+          pkgs.pkgsi686Linux.curl
+        ]
+      } $out/SLSsteam.so
+    '';
+
+    meta = {
+      description = "Steamclient Modification for Linux";
+      homepage = "https://github.com/AceSLS/SLSsteam";
+      license = lib.licenses.agpl3Only;
+      platforms = lib.platforms.linux;
+    };
+  }

--- a/nix-modules/deps.json
+++ b/nix-modules/deps.json
@@ -1,0 +1,47 @@
+[
+  {
+    "pname": "Microsoft.NETCore.Platforms",
+    "version": "5.0.0",
+    "hash": "sha256-LIcg1StDcQLPOABp4JRXIs837d7z0ia6+++3SF3jl1c="
+  },
+  {
+    "pname": "Microsoft.Win32.Registry",
+    "version": "5.0.0",
+    "hash": "sha256-9kylPGfKZc58yFqNKa77stomcoNnMeERXozWJzDcUIA="
+  },
+  {
+    "pname": "protobuf-net",
+    "version": "3.2.56",
+    "hash": "sha256-KjwRHyGwflQDjVaudT+NjRnfGhHb4CpCfn9hHVixI+E="
+  },
+  {
+    "pname": "protobuf-net.Core",
+    "version": "3.2.56",
+    "hash": "sha256-NVvLreCvvvnS/s0syL5/L3mRpXeswP7E71C6WP9f2Dc="
+  },
+  {
+    "pname": "SteamKit2",
+    "version": "3.3.1",
+    "hash": "sha256-f6kc15RKNxCSIlynlVHU8fBqQ7N8nG1xV3DNbBlRmvo="
+  },
+  {
+    "pname": "System.IO.Hashing",
+    "version": "9.0.8",
+    "hash": "sha256-Jj1XwumBjBa5LJqSVTN2naQJ0FM4wwPvZS8NxGd5Hnw="
+  },
+  {
+    "pname": "System.Security.AccessControl",
+    "version": "5.0.0",
+    "hash": "sha256-ueSG+Yn82evxyGBnE49N4D+ngODDXgornlBtQ3Omw54="
+  },
+  {
+    "pname": "System.Security.Principal.Windows",
+    "version": "5.0.0",
+    "hash": "sha256-CBOQwl9veFkrKK2oU8JFFEiKIh/p+aJO+q9Tc2Q/89Y="
+  },
+  {
+    "pname": "ZstdSharp.Port",
+    "version": "0.8.6",
+    "hash": "sha256-rc3YWP80fykqujDsD72SXOA1tBDoy2KrvVETOC8eTx8="
+  }
+]

--- a/nix-modules/ticket-grabber.nix
+++ b/nix-modules/ticket-grabber.nix
@@ -1,0 +1,18 @@
+{
+  buildDotnetModule,
+  dotnetCorePackages,
+  rev,
+}: let
+  shortRev = builtins.substring 0 7 rev;
+in
+  buildDotnetModule {
+    pname = "Ticket-Grabber";
+    version = "0.1.0+${shortRev}";
+
+    src = ../tools/ticket-grabber;
+
+    projectFile = "ticket-grabber.csproj";
+    dotnet-sdk = dotnetCorePackages.sdk_9_0;
+    dotnet-runtime = dotnetCorePackages.runtime_9_0;
+    nugetDeps = ./deps.json;
+  }

--- a/nix-modules/wrapped.nix
+++ b/nix-modules/wrapped.nix
@@ -19,7 +19,7 @@ in
     installPhase = ''
       mkdir -p $out/bin
       makeWrapper ${pkgs.steam}/bin/steam $out/bin/SLSsteam \
-        --set LD_AUDIT "${sls-steam}/SLSsteam.so"
+        --set LD_AUDIT "${sls-steam}/library-inject.so:${sls-steam}/SLSsteam.so"
     '';
 
     meta = {


### PR DESCRIPTION
Project builds on nix again.
Wrapper works as usual.

For having normal steam launches include SLSsteam, library-inject.so needs to be included in the LD_AUDIT

```nix
programs.steam.package = pkgs.steam.override {
  extraEnv = {
    LD_AUDIT = "${inputs.sls-steam.packages.${pkgs.system}.sls-steam}/library-inject.so:${inputs.sls-steam.packages.${pkgs.system}.sls-steam}/SLSsteam.so";
  };
};
```

Closes #74 