### PR TITLE
fix(memhlp): limit signature scans to the target module

### DIFF
--- a/src/memhlp.cpp
+++ b/src/memhlp.cpp
@@ -5,6 +5,7 @@
 
 #include "libmem/libmem.h"
 
+#include <algorithm>
 #include <map>
 #include <vector>
 
@@ -71,7 +72,15 @@ lm_address_t MemHlp::patternScan(const char* pattern, lm_module_t module)
 			continue;
 		}
 
-		for (lm_address_t cur = itm.first; cur < itm.second; cur++)
+		const lm_address_t sectionStart = std::max(itm.first, module.base);
+		const lm_address_t sectionEnd = std::min(itm.second, end);
+
+		if (sectionStart >= sectionEnd)
+		{
+			continue;
+		}
+
+		for (lm_address_t cur = sectionStart; cur < sectionEnd; cur++)
 		{
 			bool found = true;
 
@@ -83,7 +92,7 @@ lm_address_t MemHlp::patternScan(const char* pattern, lm_module_t module)
 				}
 
 				lm_address_t byteAddr = cur + i;
-				if (byteAddr > itm.second)
+				if (byteAddr > sectionEnd)
 				{
 					found = false;
 					break;


### PR DESCRIPTION
Fix a startup segfault in MemHlp::patternScan by restricting signature scans to the requested module instead of scanning every readable process segment. This prevents cross-module matches during early initialization, which was causing crashes on some systems.