### PR TITLE
Add DisableCloud config option and functionality

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -135,6 +135,7 @@ bool CConfig::loadSettings()
 	api = getSetting<bool>(node, "API", true);
 	fakeEmail = getSetting<std::string>(node, "FakeEmail", "");
 	fakeWalletBalance = getSetting<int32_t>(node, "FakeWalletBalance", 0);
+	disableCloud = getSetting<bool>(node, "DisableCloud", true);
 	extendedLogging = getSetting<bool>(node, "ExtendedLogging", false);
 	logLevel = getSetting<unsigned int>(node, "LogLevel", 2);
 
@@ -150,6 +151,7 @@ bool CConfig::loadSettings()
 	g_pLog->info("API: %i\n", api.get());
 	g_pLog->info("FakeEmail: %s\n", fakeEmail.get().c_str());
 	g_pLog->info("FakeWalletBalance: %i\n", fakeWalletBalance.get());
+	g_pLog->info("DisableCloud: %i\n", disableCloud.get());
 	g_pLog->info("ExtendedLogging: %i\n", extendedLogging.get());
 	g_pLog->info("LogLevel: %i\n", logLevel.get());
 

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -63,6 +63,7 @@ public:
 	MTVariable<bool> warnHashMissmatch;
 	MTVariable<bool> notifyInit;
 	MTVariable<bool> api;
+	MTVariable<bool> disableCloud;
 	MTVariable<std::string> fakeEmail;
 	MTVariable<int32_t> fakeWalletBalance;
 	MTVariable<unsigned int> logLevel;

--- a/src/config_default.hpp
+++ b/src/config_default.hpp
@@ -85,6 +85,9 @@ NotifyInit: yes
 #Enable sending commands to SLSsteam via /tmp/SLSsteam.API
 API: no
 
+#Disable cloud saves for SLSsteam-unlocked games. Set to "no" if using CloudRedirect or similar.
+DisableCloud: yes
+
 #Changes your account's E-Mail clientsided. Leave blank to disable
 FakeEmail: ""
 

--- a/src/feats/apps.cpp
+++ b/src/feats/apps.cpp
@@ -146,6 +146,9 @@ void Apps::getSubscribedApps(uint32_t* appList, size_t size, uint32_t& count)
 
 bool Apps::shouldDisableCloud(uint32_t appId)
 {
+	if (!g_config.disableCloud.get())
+		return false;
+
 	return !g_pSteamEngine->getUser(0)->isSubscribed(appId);
 }
 


### PR DESCRIPTION
Adds "DisableCloud" config option (default: yes).

When set to "no", SLSsteam will not block cloud saves for SLSsteam-unlocked games. This allows external tools to intercept
and redirect cloud sync traffic to alternative providers. The application itself will be responsible for figuring out which games are being unlocked by SLS and which are owned; I will solely rely on apps listed under 'AdditionalApps' for my first release.

