### PR TITLE
Preserve non-Steam shortcut presence

### DIFF
--- a/src/feats/apps.cpp
+++ b/src/feats/apps.cpp
@@ -282,7 +282,17 @@ void Apps::sendGamesPlayed(CMsgClientGamesPlayed* msg)
 			continue;
 		}
 
-		if(!owned && g_pSteamEngine->getUser(0)->isSubscribed(game.game_id()))
+		const uint64_t gameId = game.game_id();
+
+		// Native non-Steam shortcut IDs use 0x02000000 in their low 32 bits.
+		// Leave the original shortcut title and 64-bit ID untouched.
+		if ((gameId & 0xffffffffULL) == 0x02000000ULL)
+		{
+			g_pLog->debug("Preserving non-Steam shortcut %llu\n", gameId);
+			continue;
+		}
+
+		if(!owned && g_pSteamEngine->getUser(0)->isSubscribed(gameId))
 		{
 			owned = true;
 		}
@@ -292,21 +302,21 @@ void Apps::sendGamesPlayed(CMsgClientGamesPlayed* msg)
 			game.set_owner_id(1);
 		}
 
-		if (titles.contains(game.game_id()))
+		if (titles.contains(gameId))
 		{
-			game.set_game_extra_info(titles[game.game_id()]);
+			game.set_game_extra_info(titles[gameId]);
 		}
-		else if (!owned || FakeAppIds::getFakeAppId(game.game_id()))
+		else if (!owned || FakeAppIds::getFakeAppId(gameId))
 		{
 			char name[256] {}; //No clue how long titles can get
-			g_pClientApps->getAppData(game.game_id(), "common/name", name, sizeof(name));
+			g_pClientApps->getAppData(gameId, "common/name", name, sizeof(name));
 			g_pLog->debug("AppName %s\n", name);
 			game.set_game_extra_info(name);
 		}
 
 		msg->mutable_games_played(i)->ParseFromString(game.SerializeAsString());
 
-		g_pLog->debug("Playing game %llu with flags %u & pid %u\n", game.game_id(), game.game_flags(), game.process_id());
+		g_pLog->debug("Playing game %llu with flags %u & pid %u\n", gameId, game.game_flags(), game.process_id());
 	}
 
 	if (owned || msg->games_played_size() > 0)

--- a/src/feats/fakeappid.cpp
+++ b/src/feats/fakeappid.cpp
@@ -105,7 +105,6 @@ void FakeAppIds::getServerDetails(uint32_t handle, gameserverdetails_t& details)
 	}
 
 	const uint32_t realAppId = fakeAppIdMapServer[handle];
-
 	fakeAppIdMapPings[*reinterpret_cast<uint64_t*>(&details.address)] = realAppId;
 	details.appId = realAppId;
 
@@ -158,13 +157,22 @@ void FakeAppIds::sendMsg(CProtoBufMsgBase* msg)
 	for(int i = 0; i < body->games_played_size(); i++)
 	{
 		const auto game = body->mutable_games_played(i);
-		const uint32_t fakeAppId = FakeAppIds::getFakeAppId(game->game_id());
+		const uint64_t gameId = game->game_id();
+
+		// Native non-Steam shortcut IDs use 0x02000000 in their low 32 bits.
+		// Preserve the original 64-bit shortcut ID instead of applying a fake AppID.
+		if ((gameId & 0xffffffffULL) == 0x02000000ULL)
+		{
+			continue;
+		}
+
+		const uint32_t fakeAppId = FakeAppIds::getFakeAppId(gameId);
 		if (!fakeAppId)
 		{
 			continue;
 		}
 
-		g_pLog->debug("Setting %llu to %u\n", game->game_id(), fakeAppId);
+		g_pLog->debug("Setting %llu to %u\n", gameId, fakeAppId);
 		game->set_game_id(fakeAppId);
 	}
 }


### PR DESCRIPTION
## Summary

- Preserve native non-Steam shortcut titles in `Apps::sendGamesPlayed`
- Preserve their original 64-bit IDs in `FakeAppIds::sendMsg`
- Detect shortcuts by the `0x02000000` low-word marker

## Why

Steam ROM Manager shortcuts use 64-bit game IDs and already include the correct title. SLSsteam can treat them like regular Steam apps, replace the title with missing `common/name` metadata, and display a generic **Non-Steam Game** status.

The check is applied per `GamesPlayed` entry, so normal SLSsteam behavior remains unchanged for regular games.

## Validation

An equivalent patch was built and tested successfully on Steam Deck with the slsteam-moon fork.