### PR TITLE
feat(apps): filter playtime RPC for AdditionalApps

### DIFF
--- a/src/feats/apps.cpp
+++ b/src/feats/apps.cpp
@@ -344,6 +344,44 @@ void Apps::sendPICSInfoRequest(CMsgClientPICSProductInfoRequest* msg)
 	}
 }
 
+void Apps::filterLastPlayedTimes(const char* name, void* recv)
+{
+	if (!recv || !name)
+	{
+		return;
+	}
+
+	if (strcmp(name, "Player.ClientGetLastPlayedTimes#1") != 0)
+	{
+		return;
+	}
+
+	auto* response = static_cast<CPlayer_GetLastPlayedTimes_Response*>(recv);
+	if (!response->games_size())
+	{
+		return;
+	}
+
+	auto addedIds = g_config.addedAppIds.get();
+	bool filtered = false;
+
+	for (int i = response->games_size() - 1; i >= 0; i--)
+	{
+		const uint32_t appId = static_cast<uint32_t>(response->games(i).appid());
+		if (addedIds.contains(appId))
+		{
+			g_pLog->debug("Filtered playtime for AdditionalApp %u\n", appId);
+			response->mutable_games()->DeleteSubrange(i, 1);
+			filtered = true;
+		}
+	}
+
+	if (filtered)
+	{
+		g_pLog->info("Filtered playtime response for AdditionalApp(s)\n");
+	}
+}
+
 void Apps::sendMsg(CProtoBufMsgBase *msg)
 {
 	switch(msg->type)

--- a/src/feats/apps.hpp
+++ b/src/feats/apps.hpp
@@ -28,6 +28,8 @@ namespace Apps
 	bool shouldDisableCDKey(uint32_t appId);
 	bool shouldDisableUpdates(uint32_t appId);
 
+	void filterLastPlayedTimes(const char* name, void* recv);
+
 	void sendGamesPlayed(CMsgClientGamesPlayed* msg);
 	void sendPICSInfoRequest(CMsgClientPICSProductInfoRequest* msg);
 	void sendMsg(CProtoBufMsgBase* msg);

--- a/src/hooks.cpp
+++ b/src/hooks.cpp
@@ -227,6 +227,8 @@ static uint32_t hkClientUnifiedServiceTransport_SendAndRecvMsg(CClientUnifiedSer
 		ret = Hooks::CClientUnifiedServiceMethod_SendAndRecvMsg.tramp.fn(pUnifiedServiceTransport, name, send, recv, arg4);
 	}
 
+	Apps::filterLastPlayedTimes(name, recv);
+
 	g_pLog->debug
 	(
 		"%s(%p, %s, %s, %s, %p) -> %u\n",


### PR DESCRIPTION
Intercept `Player.ClientGetLastPlayedTimes#1` response to strip `AdditionalApps` entries, preventing Steam Cloud from overwriting local playtime with stale server data on restart.