### PR TITLE
chore(SafeMode): Add client hash from 2026.07.21

### DIFF
--- a/res/updates.yaml
+++ b/res/updates.yaml
@@ -38,3 +38,6 @@ SafeModeHashes:
   20260714131044: #tag 20260714131044
     - f5eb8bd3e98ac34b9f4610d9303cc4fbd931c672cb2d21b126e687bab95d9a95 #ubuntu12_32 & steamdeck_stable - 20260625
     - fa20a21df061aad7a5d4f1e793385fcf593dcb677d0bb74f4d29ce62f2bd858e #steamdeck_stable - 20260701
+
+  20260721234251:
+    - dd3ca9f549224da3e5514fecd9887d3bf3a8a219ff123d50fe3f7b5af888af19 #ubuntu12_32 & steamdeck_stable - 20260721 (client 1784669098)

--- a/src/patterns.cpp
+++ b/src/patterns.cpp
@@ -142,7 +142,7 @@ namespace Patterns
 		Pattern_t RequestInternetServerList
 		{
 			"CSteamMatchmakingServers::RequestInternetServerList",
-			"C7 04 24 50 03 00 00 E8 ? ? ? ? 5A 89 45 ? 59 FF B6 ? ? ? ? FF B6 ? ? ? ? FF B6 ? ? ? ? FF B6 ? ? ? ? FF B6 ? ? ? ? 6A 01",
+			"C7 04 24 54 03 00 00 E8 ? ? ? ? 5A 89 45 ? 59 FF B6 ? ? ? ? FF B6 ? ? ? ? FF B6 ? ? ? ? FF B6 ? ? ? ? FF B6 ? ? ? ? 6A 01",
 			SigFollowMode::PrologueUpwards,
 			std::vector<uint8_t> { 0xe8, 0x57, 0xe5, 0x89, 0x55 }
 		};
@@ -230,7 +230,7 @@ namespace Patterns
 		Pattern_t RunIPCFrame
 		{
 			"IClientRemoteStorage::RunIPCFrame",
-			"E8 ? ? ? ? 8B 85 ? ? ? ? 83 C4 10 3D ? E8 2F 87",
+			"E8 ? ? ? ? 8B 85 ? ? ? ? 83 C4 10 3D ? DD 12 87",
 			SigFollowMode::PrologueUpwards,
 			std::vector<uint8_t> { 0x56, 0x57, 0xe5, 0x89, 0x55 }
 		};


### PR DESCRIPTION
## Summary
- Adds the `steamclient.so` SHA256 for Steam client build `1784669098` (steamdeck_stable) to `SafeModeHashes` in `res/updates.yaml`.

Opening on Ace's behalf since his internet is fucking deaddd

Missed the mismatched patterns due to SLS not actually injecting on my system and I didn't notice, now properly fixed

## Test plan
- [x] Verified against a freshly-updated live Steam Deck install (Steam self-updated from build 1782861641 -> 1784669098).
- [x] Hash confirmed as `sha256sum` of `~/.local/share/Steam/ubuntu12_32/steamclient.so` post-update.