### PR TITLE
fix(sdk): update stale patterns for client 1784669098

### DIFF
--- a/src/patterns.cpp
+++ b/src/patterns.cpp
@@ -142,7 +142,7 @@ namespace Patterns
 		Pattern_t RequestInternetServerList
 		{
 			"CSteamMatchmakingServers::RequestInternetServerList",
-			"C7 04 24 50 03 00 00 E8 ? ? ? ? 5A 89 45 ? 59 FF B6 ? ? ? ? FF B6 ? ? ? ? FF B6 ? ? ? ? FF B6 ? ? ? ? FF B6 ? ? ? ? 6A 01",
+			"C7 04 24 54 03 00 00 E8 ? ? ? ? 5A 89 45 ? 59 FF B6 ? ? ? ? FF B6 ? ? ? ? FF B6 ? ? ? ? FF B6 ? ? ? ? FF B6 ? ? ? ? 6A 01",
 			SigFollowMode::PrologueUpwards,
 			std::vector<uint8_t> { 0xe8, 0x57, 0xe5, 0x89, 0x55 }
 		};
@@ -230,7 +230,7 @@ namespace Patterns
 		Pattern_t RunIPCFrame
 		{
 			"IClientRemoteStorage::RunIPCFrame",
-			"E8 ? ? ? ? 8B 85 ? ? ? ? 83 C4 10 3D ? E8 2F 87",
+			"E8 ? ? ? ? 8B 85 ? ? ? ? 83 C4 10 3D ? DD 12 87",
 			SigFollowMode::PrologueUpwards,
 			std::vector<uint8_t> { 0x56, 0x57, 0xe5, 0x89, 0x55 }
 		};


### PR DESCRIPTION
## Summary
Two signatures went stale against the latest Steam client (build 1784669098, steamdeck_stable) and were causing SLSsteam to hard-abort on launch ("Failed to find all patterns! Aborting...").

- `IClientRemoteStorage::RunIPCFrame`: the trailing constant in the `cmp eax, imm32` anchor changed from `E8 2F 87` to `DD 12 87`.
- `CSteamMatchmakingServers::RequestInternetServerList`: a struct grew by 4 bytes, shifting the `mov dword ptr [esp], imm32` size constant from `0x350` to `0x354`.

Both were re-derived from the live `ubuntu12_32/steamclient.so` for this build and confirmed unique matches (single hit each across the whole binary). Live-verified end-to-end: with `SafeMode: false`, SLSsteam now loads and hooks successfully with `[Notify] Loaded successfully` and no signature failures, where it previously aborted every launch.

Note: this doesn't touch `res/updates.yaml` — that's already covered by #137 (adds the SafeModeHashes entry for this same client build). With both merged, `SafeMode: true` should also work cleanly again.

## Test plan
- [x] Rebuilt against a git worktree tracking `main` (`9cc2ff2`) on a Steam Deck (CachyOS)
- [x] Deployed and relaunched live against steamclient.so build 1784669098
- [x] Confirmed `IClientRemoteStorage::RunIPCFrame` and `RequestInternetServerList` both resolve (previously only RemoteStorage was silently failing; RequestInternetServerList only surfaced after fixing RemoteStorage)
- [x] Confirmed `[Notify] Loaded successfully` and VFT hooks placing correctly with no aborts