### PR TITLE
Sync AdditionalApps without restarting Steam

### DIFF
--- a/res/config.yaml
+++ b/res/config.yaml
@@ -37,6 +37,11 @@ AppIds:
 #It will get ignored in exclusion checks for the parent AppId
 AdditionalApps:
 
+#Synchronize AdditionalApps to currently connected Steam Remote Play clients.
+#The receiver keeps them in memory only; this never writes them into its config.yaml.
+#Experimental and disabled by default while RemoteClient compatibility is validated.
+SyncRemoteAdditionalApps: no
+
 #Extra Data for Dlcs belonging to a specific AppId. Only needed
 #when the App you're playing is hit by Steams 64 DLC limit
 DlcData:

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1,6 +1,7 @@
 #include "config.hpp"
 #include "config_default.hpp"
 
+#include "feats/apps.hpp"
 #include "filewatcher.hpp"
 #include "log.hpp"
 #include "utils.hpp"
@@ -181,12 +182,18 @@ bool CConfig::loadSettings(bool firstLoad)
 	fakeWalletBalance = getSetting<int32_t>(node, "FakeWalletBalance", 0);
 	disableCloud = getSetting<bool>(node, "DisableCloud", true);
 	disableUpdates = getSetting<bool>(node, "DisableUpdates", true);
+	//Keep existing configs compatible: this experimental feature is opt-in until
+	//the RemoteClient packet layout and multi-host behavior are fully validated.
+	syncRemoteAdditionalApps = node["SyncRemoteAdditionalApps"]
+		? getSetting<bool>(node, "SyncRemoteAdditionalApps", false)
+		: false;
 	dumpInterfaceMaps = getSetting<bool>(node, "DumpClientInterfaces", false);
 	extendedLogging = getSetting<bool>(node, "ExtendedLogging", false);
 
 	const std::lock_guard appsChanged(appsChangedMutex);
 	const auto prevAppIds = addedAppIds.get();
 	const auto _addedAppIds = getList<AppId_t>(node, "AdditionalApps");
+	bool localAppsRemoved = false;
 
 	if (!firstLoad)
 	{
@@ -198,6 +205,7 @@ bool CConfig::loadSettings(bool firstLoad)
 			}
 
 			removedApps.emplace(appId);
+			localAppsRemoved = true;
 			LOG_DEBUG("AppId %u removed from AdditionalApps\n", appId);
 		}
 		for (const auto& appId : _addedAppIds)
@@ -213,6 +221,13 @@ bool CConfig::loadSettings(bool firstLoad)
 	}
 
 	addedAppIds = _addedAppIds;
+	if (localAppsRemoved && syncRemoteAdditionalApps.get())
+	{
+		//Queue only after addedAppIds contains the complete new snapshot. The
+		//Steam IPC thread can now broadcast without racing this config reload.
+		Apps::requestRemoteAppBroadcast();
+		LOG_DEBUG("REMOTE BROADCAST QUEUED reason=config-remove\n");
+	}
 
 	appIds = getList<AppId_t>(node, "AppIds");
 	fakeOffline = getList<AppId_t>(node, "FakeOffline");

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -70,6 +70,7 @@ public:
 	MTVariable<bool> api;
 	MTVariable<bool> disableCloud;
 	MTVariable<bool> disableUpdates;
+	MTVariable<bool> syncRemoteAdditionalApps;
 	MTVariable<std::string> fakeName;
 	MTVariable<std::string> fakeEmail;
 	MTVariable<int32_t> fakeWalletBalance;

--- a/src/config_default.hpp
+++ b/src/config_default.hpp
@@ -39,6 +39,11 @@ AppIds:
 #It will get ignored in exclusion checks for the parent AppId
 AdditionalApps:
 
+#Synchronize AdditionalApps to currently connected Steam Remote Play clients.
+#The receiver keeps them in memory only; this never writes them into its config.yaml.
+#Experimental and disabled by default while RemoteClient compatibility is validated.
+SyncRemoteAdditionalApps: no
+
 #Extra Data for Dlcs belonging to a specific AppId. Only needed
 #when the App you're playing is hit by Steams 64 DLC limit
 DlcData:

--- a/src/feats/apps.cpp
+++ b/src/feats/apps.cpp
@@ -6,6 +6,7 @@
 
 #include "fakeappid.hpp"
 
+#include <atomic>
 #include <cmath>
 #include <cstdint>
 #include <cstdlib>
@@ -20,6 +21,106 @@ std::unordered_set<AppId_t> Apps::privateApps = std::unordered_set<AppId_t>();
 
 std::mutex Apps::pendingLicenseChangesMutex;
 std::unordered_set<AppId_t> Apps::pendingLicenseChanges = std::unordered_set<AppId_t>();
+
+namespace
+{
+	std::mutex remoteAppsMutex;
+	std::unordered_set<AppId_t> remoteApps;
+	std::atomic_bool remoteAppBroadcastRequested = false;
+}
+
+bool Apps::updateRemoteApps(const std::unordered_set<AppId_t>& appIds)
+{
+	std::unordered_set<AppId_t> added;
+	std::unordered_set<AppId_t> removed;
+
+	{
+		const std::lock_guard lock(remoteAppsMutex);
+
+		for (const auto appId : appIds)
+		{
+			if (!remoteApps.contains(appId))
+			{
+				added.emplace(appId);
+			}
+		}
+
+		for (const auto appId : remoteApps)
+		{
+			if (!appIds.contains(appId))
+			{
+				removed.emplace(appId);
+			}
+		}
+
+		remoteApps = appIds;
+	}
+
+	if (!added.size() && !removed.size())
+	{
+		return false;
+	}
+
+	{
+		const std::lock_guard lock(g_config.appsChangedMutex);
+
+		for (const auto appId : added)
+		{
+			g_config.removedApps.erase(appId);
+			if (!g_config.isAddedAppId(appId))
+			{
+				g_config.newApps.emplace(appId);
+				LOG_DEBUG("REMOTE REGISTER app=%u queued for AppInfo\n", appId);
+			}
+			else
+			{
+				LOG_DEBUG("REMOTE REGISTER app=%u already present locally\n", appId);
+			}
+		}
+
+		for (const auto appId : removed)
+		{
+			g_config.newApps.erase(appId);
+			if (!g_config.isAddedAppId(appId))
+			{
+				g_config.removedApps.emplace(appId);
+			}
+			LOG_DEBUG("REMOTE REMOVE app=%u\n", appId);
+		}
+	}
+
+	if (removed.size())
+	{
+		const std::lock_guard lock(pendingLicenseChangesMutex);
+		for (const auto appId : removed)
+		{
+			pendingLicenseChanges.erase(appId);
+		}
+	}
+
+	return added.size();
+}
+
+bool Apps::isRemoteApp(const AppId_t appId)
+{
+	const std::lock_guard lock(remoteAppsMutex);
+	return remoteApps.contains(appId);
+}
+
+void Apps::requestRemoteAppBroadcast()
+{
+	remoteAppBroadcastRequested.store(true);
+}
+
+bool Apps::hasRemoteAppBroadcastRequest()
+{
+	return remoteAppBroadcastRequested.load();
+}
+
+bool Apps::consumeRemoteAppBroadcastRequest()
+{
+	return remoteAppBroadcastRequested.exchange(false);
+}
 
 bool Apps::unlockApp(const AppId_t appId, AppOwnershipInfo_t* info, const CSteamId& ownerId)
 {
@@ -109,7 +210,9 @@ bool Apps::checkAppOwnership(AppId_t appId, AppOwnershipInfo_t* pInfo)
 		return false;
 	}
 
-	if (g_config.shouldExcludeAppId(appId))
+	const bool remoteApp = isRemoteApp(appId);
+
+	if (!remoteApp && g_config.shouldExcludeAppId(appId))
 	{
 		return false;
 	}
@@ -131,7 +234,7 @@ bool Apps::checkAppOwnership(AppId_t appId, AppOwnershipInfo_t* pInfo)
 		pInfo->purchaseTime = times.at(appId);
 	}
 
-	if (!g_config.isAddedAppId(appId))
+	if (!remoteApp && !g_config.isAddedAppId(appId))
 	{
 		return false;
 	}
@@ -204,16 +307,28 @@ void Apps::getLegacyCDKey(const AppId_t appId)
 
 void Apps::getSubscribedApps(AppId_t* appList, const size_t size, uint32_t& count)
 {
+	auto apps = g_config.addedAppIds.get();
+	{
+		const std::lock_guard lock(remoteAppsMutex);
+		apps.insert(remoteApps.begin(), remoteApps.end());
+	}
+
 	//Valve calls this function twice, once with size of 0 then again
 	if (!size || !appList)
 	{
-		count = count + g_config.addedAppIds.get().size();
+		count = count + apps.size();
 		return;
 	}
 
 	//TODO: Maybe Add check if AppId already in list before blindly appending
-	for (auto& appId : g_config.addedAppIds.get())
+	for (auto& appId : apps)
 	{
+		if (count >= size)
+		{
+			LOG_WARN("GetSubscribedApps has no room for transient app %u\n", appId);
+			break;
+		}
+
 		appList[count++] = appId;
 	}
 
@@ -222,24 +337,44 @@ void Apps::getSubscribedApps(AppId_t* appList, const size_t size, uint32_t& coun
 
 void Apps::parseProductInfoFromResponse(CMsgClientPICSProductInfoResponse* msg)
 {
-	std::lock_guard lock(pendingLicenseChangesMutex);
-
 	auto set = std::unordered_set<AppId_t>();
-	for (const auto& app : msg->apps())
 	{
-		if (!pendingLicenseChanges.contains(app.appid()))
-		{
-			continue;
-		}
+		const std::lock_guard lock(pendingLicenseChangesMutex);
 
-		set.emplace(app.appid());
-		pendingLicenseChanges.erase(app.appid());
+		for (const auto& app : msg->apps())
+		{
+			if (!pendingLicenseChanges.contains(app.appid()))
+			{
+				continue;
+			}
+
+			set.emplace(app.appid());
+			pendingLicenseChanges.erase(app.appid());
+		}
 	}
 
 	postAppLicensesChanged(set);
+
+	for (const auto appId : set)
+	{
+		if (isRemoteApp(appId))
+		{
+			LOG_DEBUG("REMOTE READY app=%u metadata received\n", appId);
+		}
+	}
+
+	for (const auto appId : set)
+	{
+		if (g_config.isAddedAppId(appId))
+		{
+			requestRemoteAppBroadcast();
+			LOG_DEBUG("REMOTE BROADCAST QUEUED reason=metadata app=%u\n", appId);
+			break;
+		}
+	}
 }
 
-void Apps::postAppLicensesChanged(const std::unordered_set<AppId_t>& apps)
+void Apps::postAppLicensesChanged(const std::unordered_set<AppId_t>& apps, const bool appsAdded)
 {
 	if (!apps.size())
 	{
@@ -261,7 +396,10 @@ void Apps::postAppLicensesChanged(const std::unordered_set<AppId_t>& apps)
 
 		cb.apps[idx] = *std::next(apps.begin(), i);
 		cb.count = idx + 1;
-		cb.appsAdded |= 1llu << idx;
+		if (appsAdded)
+		{
+			cb.appsAdded |= 1llu << idx;
+		}
 		cb.remainingPackets = totalPackets;
 
 		LOG_DEBUG("AppLicensesChanged_t.apps[%u] -> %u (i -> %i, packets left -> %i, appsAdded %llu)\n", idx, cb.apps[idx], i, totalPackets, cb.appsAdded);
@@ -290,6 +428,11 @@ void Apps::postAppLicensesChanged(const std::unordered_set<AppId_t>& apps)
 
 void Apps::runIPCFrame()
 {
+	if (!g_config.syncRemoteAdditionalApps.get())
+	{
+		updateRemoteApps({});
+	}
+
 	const auto usr = g_pSteamEngine->getUser();
 	if (!usr)
 	{
@@ -301,7 +444,7 @@ void Apps::runIPCFrame()
 
 	if (g_config.removedApps.size())
 	{
-		postAppLicensesChanged(g_config.removedApps);
+		postAppLicensesChanged(g_config.removedApps, false);
 		g_config.removedApps.clear();
 	}
 
@@ -369,7 +512,7 @@ bool Apps::shouldDisableUpdates(const AppId_t appId)
 	}
 
 	//Using AdditionalApps here aswell so users can manually block updates
-	return g_config.isAddedAppId(appId) || !g_pSteamEngine->getUser(0)->isSubscribed(appId);
+	return isRemoteApp(appId) || g_config.isAddedAppId(appId) || !g_pSteamEngine->getUser(0)->isSubscribed(appId);
 }
 
 void Apps::sendAndRecvLastPlayedTimes(const char* name, CPlayer_GetLastPlayedTimes_Response* recv)

--- a/src/feats/apps.hpp
+++ b/src/feats/apps.hpp
@@ -15,6 +15,12 @@ namespace Apps
 	extern std::mutex pendingLicenseChangesMutex;
 	extern std::unordered_set<AppId_t> pendingLicenseChanges;
 
+	bool updateRemoteApps(const std::unordered_set<AppId_t>& appIds);
+	bool isRemoteApp(const AppId_t appId);
+	void requestRemoteAppBroadcast();
+	bool hasRemoteAppBroadcastRequest();
+	bool consumeRemoteAppBroadcastRequest();
+
 	bool unlockApp(const AppId_t appId, AppOwnershipInfo_t* info, const CSteamId& ownerId);
 	bool unlockApp(const AppId_t appId, AppOwnershipInfo_t* info);
 
@@ -25,7 +31,7 @@ namespace Apps
 	void parseProductInfoFromResponse(CMsgClientPICSProductInfoResponse* msg);
 	void runIPCFrame();
 
-	void postAppLicensesChanged(const std::unordered_set<AppId_t>& apps);
+	void postAppLicensesChanged(const std::unordered_set<AppId_t>& apps, const bool appsAdded = true);
 
 	bool shouldDisableCloud(const AppId_t appId);
 	bool shouldDisableCDKey(const AppId_t appId);

--- a/src/filewatcher.cpp
+++ b/src/filewatcher.cpp
@@ -44,7 +44,10 @@ void* watchLoop(void* args)
 
 			auto path = watcher->fileFdMap[event->wd];
 			
-			if (!(event->mask & IN_CLOSE_WRITE))
+			//Editors and tools such as `sed -i` commonly save by renaming a
+			//temporary file over the original. Since we watch the parent directory,
+			//handle both direct writes and those atomic replacement saves.
+			if (!(event->mask & (IN_CLOSE_WRITE | IN_MOVED_TO)))
 			{
 				continue;
 			}
@@ -99,7 +102,12 @@ int CFileWatcher::addFile(const char* path)
 	//Watching seperate files does not seem to work very well, since the file descriptor becomes useless
 	//on some operations
 	const std::filesystem::path p(path);
-	int fd = inotify_add_watch(notifyFd, p.parent_path().c_str(), IN_CLOSE_WRITE);
+	int fd = inotify_add_watch
+	(
+		notifyFd,
+		p.parent_path().c_str(),
+		IN_CLOSE_WRITE | IN_MOVED_TO
+	);
 	if (fd == -1)
 	{
 		return fd;

--- a/src/hooks.cpp
+++ b/src/hooks.cpp
@@ -18,6 +18,7 @@
 
 #include "libmem/libmem.h"
 
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
@@ -26,6 +27,7 @@
 #include <mutex>
 #include <pthread.h>
 #include <strings.h>
+#include <unordered_set>
 #include <unistd.h>
 #include <vector>
 
@@ -313,6 +315,244 @@ static void hkCMInterface_RecvPkt(CCMInterface* pCMInterface, CNetPacket* pNetPa
 	Hooks::CCMInterface_RecvPkt.tramp.fn(pCMInterface, pNetPacket);
 }
 
+static uint32_t hkRemoteClientProtoDecode(
+    CProtoBufMsgBase* pMsg,
+    void* pSource)
+{
+    const uint32_t ret =
+        Hooks::CRemoteClientProtoDecode.tramp.fn(pMsg, pSource);
+
+    if (!pMsg || !pMsg->__pBody)
+    {
+        return ret;
+    }
+
+    if (static_cast<unsigned int>(pMsg->getProtoBufType()) != 9502)
+    {
+        return ret;
+    }
+
+	const bool syncEnabled = g_config.syncRemoteAdditionalApps.get();
+
+    const auto* body =
+        reinterpret_cast<const uint8_t*>(pMsg->__pBody);
+
+    const int32_t count =
+        *reinterpret_cast<const int32_t*>(body + 0x0c);
+
+    const uintptr_t repAddress =
+        *reinterpret_cast<const uintptr_t*>(body + 0x14);
+
+    std::unordered_set<AppId_t> candidates;
+    auto* usr = g_pSteamEngine ? g_pSteamEngine->getUser() : nullptr;
+
+    const bool validStatus = count >= 0 && count < 100000 && repAddress;
+
+    if (validStatus)
+    {
+        const auto* rep =
+            reinterpret_cast<const uint8_t*>(repAddress);
+
+        for (int32_t i = 0; i < count; ++i)
+        {
+            const uintptr_t statusAddress =
+                *reinterpret_cast<const uintptr_t*>(
+                    rep + 4 + (i * sizeof(uintptr_t))
+                );
+
+            if (!statusAddress)
+            {
+                continue;
+            }
+
+            const auto* status =
+                reinterpret_cast<const uint8_t*>(statusAddress);
+
+            const uint32_t appId =
+                *reinterpret_cast<const uint32_t*>(status + 0x1c);
+
+            const uint32_t hasBits =
+                *reinterpret_cast<const uint32_t*>(status + 0x08);
+            const uint32_t appState =
+                *reinterpret_cast<const uint32_t*>(status + 0x20);
+
+            if (usr && hasBits == 0x1fc && appState == 0x4)
+            {
+                AppOwnershipInfo_t ownership {};
+                const bool ownershipCheck =
+                    usr->checkAppOwnership(appId, &ownership);
+
+                if (ownershipCheck && !ownership.ownsLicense)
+                {
+                    candidates.emplace(appId);
+                    LOG_DEBUG
+                    (
+                        "REMOTE CANDIDATE app=%u idx=%d has=0x%x "
+                        "state=0x%x owns=%u expired=%u release=%d sub=%d\n",
+                        appId,
+                        i,
+                        hasBits,
+                        appState,
+                        ownership.ownsLicense,
+                        ownership.licenseExpired,
+                        ownership.releaseState,
+                        ownership.subId
+                    );
+                }
+            }
+        }
+    }
+
+    //EMsg 9502 carries both complete app lists and small incremental updates,
+    //without a protobuf field that distinguishes them. Learn the size of the
+    //first complete list and require later replacement snapshots to remain in
+    //the same broad size range. This prevents count=1 updates from clearing all
+    //transient remote apps while still allowing normal list growth/shrinkage.
+    static std::atomic<int32_t> fullStatusEntryCount = 0;
+    const int32_t previousFullCount = fullStatusEntryCount.load();
+    const int32_t fullCountFloor = previousFullCount > 4
+        ? previousFullCount / 2
+        : 2;
+    const bool fullSnapshot =
+        validStatus
+        && count >= fullCountFloor;
+
+    if (fullSnapshot)
+    {
+        fullStatusEntryCount.store(count);
+    }
+
+    bool registered = false;
+    if (syncEnabled && fullSnapshot && usr)
+    {
+        registered = Apps::updateRemoteApps(candidates);
+    }
+
+	const int32_t clientSessionId =
+		pMsg->header && pMsg->header->has_client_sessionid()
+			? pMsg->header->client_sessionid()
+			: -1;
+	const uint64_t sourceJobId =
+		pMsg->header && pMsg->header->has_jobid_source()
+			? pMsg->header->jobid_source()
+			: 0;
+
+    LOG_DEBUG
+    (
+        "RemoteAppStatus RX count=%d candidates=%zu session=%d "
+        "sourceJob=%llu source=%p sync=%u full=%u fullCount=%d\n",
+        count,
+        candidates.size(),
+		clientSessionId,
+		static_cast<unsigned long long>(sourceJobId),
+        pSource,
+		syncEnabled,
+        fullSnapshot,
+        fullStatusEntryCount.load()
+    );
+
+    if (registered)
+    {
+        LOG_DEBUG("REMOTE PACKET REPLAY candidates=%zu\n", candidates.size());
+        Hooks::CRemoteClientProtoDecode.tramp.fn(pMsg, pSource);
+    }
+
+    return ret;
+}
+
+
+
+static bool hkRemoteClientManager_UpdateRemoteAppState(
+    void* pRemoteClient,
+    AppId_t appId,
+    uint32_t appState,
+    uint32_t flag,
+    void* pOut)
+{
+    const bool ret =
+        Hooks::CRemoteClientManager_UpdateRemoteAppState.tramp.fn(
+            pRemoteClient,
+            appId,
+            appState,
+            flag,
+            pOut
+        );
+
+    if (Apps::isRemoteApp(appId))
+    {
+        uint32_t outValue = 0;
+
+        if (pOut)
+        {
+            outValue = *reinterpret_cast<uint32_t*>(pOut);
+        }
+
+        LOG_DEBUG
+        (
+            "RemoteAppState app=%u state=0x%x flag=%u "
+            "ret=%u out=%p outValue=0x%x\n",
+            appId,
+            appState,
+            flag,
+            ret,
+            pOut,
+            outValue
+        );
+    }
+
+    return ret;
+}
+
+static std::atomic<void*> g_pRemoteClientManager = nullptr;
+
+static void hkRemoteClientManager_BroadcastAppStatus(void* pRemoteClientManager)
+{
+	const void* previous = g_pRemoteClientManager.exchange(pRemoteClientManager);
+	if (previous != pRemoteClientManager)
+	{
+		LOG_DEBUG("RemoteAppStatus TX manager=%p captured\n", pRemoteClientManager);
+	}
+
+	const bool pending = Apps::consumeRemoteAppBroadcastRequest();
+
+	Hooks::CRemoteClientManager_BroadcastAppStatus.tramp.fn(pRemoteClientManager);
+
+	if (pending)
+	{
+		LOG_DEBUG("REMOTE BROADCAST SATISFIED source=native manager=%p\n", pRemoteClientManager);
+	}
+}
+
+static void runRemoteAppBroadcast()
+{
+	if (!g_config.syncRemoteAdditionalApps.get())
+	{
+		Apps::consumeRemoteAppBroadcastRequest();
+		return;
+	}
+
+	if (!Apps::hasRemoteAppBroadcastRequest())
+	{
+		return;
+	}
+
+	void* pRemoteClientManager = g_pRemoteClientManager.load();
+	if (!pRemoteClientManager)
+	{
+		return;
+	}
+
+	//Atomically claim the request on Steam's IPC thread immediately before
+	//building the fresh status packet. A concurrent new request remains queued.
+	if (!Apps::consumeRemoteAppBroadcastRequest())
+	{
+		return;
+	}
+	LOG_DEBUG("REMOTE BROADCAST REFRESH manager=%p\n", pRemoteClientManager);
+	Hooks::CRemoteClientManager_BroadcastAppStatus.tramp.fn(pRemoteClientManager);
+}
+
+
 //I don't like forward declerations, but with the current style & hooks layout it's a necessity
 static CSteamId hkClientUser_GetSteamId(const CSteamId& steamId);
 
@@ -415,6 +655,7 @@ static uint32_t hkSteamEngine_ProcessIPCFrame(CSteamEngine* pSteamEngine, HSteam
 		//LOG_DEBUG("Out\n%s\n", MemHlp::hexdump(pBufOut->mem.base, pBufOut->offset).c_str());
 
 		Apps::runIPCFrame();
+		runRemoteAppBroadcast();
 		SLSAPI::runIPCFrame();
 	}
 	else
@@ -1160,6 +1401,10 @@ namespace Hooks
 
 	DetourHook<CCMInterface_RecvPkt_t> CCMInterface_RecvPkt;
 
+	DetourHook<CRemoteClientProtoDecode_t> CRemoteClientProtoDecode;
+	DetourHook<CRemoteClientManager_BroadcastAppStatus_t> CRemoteClientManager_BroadcastAppStatus;
+	DetourHook<CRemoteClientManager_UpdateRemoteAppState_t> CRemoteClientManager_UpdateRemoteAppState;
+
 	DetourHook<CSteamMatchmakingServers_GetServerDetails_t> CSteamMatchmakingServers_GetServerDetails;
 	DetourHook<CSteamMatchmakingServers_RequestInternetServerList_t> CSteamMatchmakingServers_RequestInternetServerList;
 
@@ -1298,6 +1543,24 @@ bool Hooks::setup()
 		//To lazy to move this for now. Doesn't really matter wheter we detour or vft hook
 		&& CCMInterface_RecvPkt.setup(VFTIndexes::CCMInterface::RecvPkt, hkCMInterface_RecvPkt)
 
+		&& CRemoteClientProtoDecode.setup
+		(
+			Patterns::CRemoteClient::DecodeAppStatus,
+			hkRemoteClientProtoDecode
+		)
+
+		&& CRemoteClientManager_BroadcastAppStatus.setup
+		(
+			Patterns::CRemoteClientManager::BroadcastAppStatus,
+			hkRemoteClientManager_BroadcastAppStatus
+		)
+
+		&& CRemoteClientManager_UpdateRemoteAppState.setup
+		(
+			Patterns::CRemoteClientManager::UpdateRemoteAppState,
+			hkRemoteClientManager_UpdateRemoteAppState
+		)
+
 		&& CSteamMatchmakingServers_GetServerDetails.setup(VFTIndexes::CSteamMatchmakingServers::GetServerDetails, hkSteamMatchmakingServers_GetServerDetails)
 		&& CSteamMatchmakingServers_RequestInternetServerList.setup(VFTIndexes::CSteamMatchmakingServers::RequestInternetServerList, hkSteamMatchmakingServers_RequestInternetServerList)
 
@@ -1332,6 +1595,10 @@ void Hooks::place()
 	CClientUnifiedServiceMethod_SendAndRecvMsg.place();
 
 	CCMInterface_RecvPkt.place();
+
+	CRemoteClientProtoDecode.place();
+	CRemoteClientManager_BroadcastAppStatus.place();
+	CRemoteClientManager_UpdateRemoteAppState.place();
 
 	CSteamEngine_ProcessIPCFrame.place();
 	CSteamEngine_SetAppIdForCurrentPipe.place();
@@ -1473,6 +1740,10 @@ void Hooks::remove()
 	CClientUnifiedServiceMethod_SendAndRecvMsg.remove();
 
 	CCMInterface_RecvPkt.remove();
+
+	CRemoteClientProtoDecode.remove();
+	CRemoteClientManager_BroadcastAppStatus.remove();
+	CRemoteClientManager_UpdateRemoteAppState.remove();
 
 	CSteamEngine_ProcessIPCFrame.remove();
 	CSteamEngine_SetAppIdForCurrentPipe.remove();

--- a/src/hooks.hpp
+++ b/src/hooks.hpp
@@ -82,6 +82,10 @@ namespace Hooks
 
 	typedef void(*CCMInterface_RecvPkt_t)(CCMInterface*, CNetPacket*);
 
+	typedef uint32_t(*CRemoteClientProtoDecode_t)(CProtoBufMsgBase*, void*);
+	typedef void(*CRemoteClientManager_BroadcastAppStatus_t)(void*);
+	typedef bool(*CRemoteClientManager_UpdateRemoteAppState_t)(void*, AppId_t, uint32_t, uint32_t, void*);
+
 	typedef uint32_t(*CSteamEngine_ProcessIPCFrame_t)(CSteamEngine*, HSteamPipe, CUtlBuffer*, CUtlBuffer*);
 	typedef AppId_t(*CSteamEngine_SetAppIdForCurrentPipe_t)(CSteamEngine*, AppId_t, bool);
 
@@ -113,6 +117,10 @@ namespace Hooks
 	extern DetourHook<CClientUnifiedServiceMethod_SendAndRecvMsg_t> CClientUnifiedServiceMethod_SendAndRecvMsg;
 
 	extern DetourHook<CCMInterface_RecvPkt_t> CCMInterface_RecvPkt;
+
+	extern DetourHook<CRemoteClientProtoDecode_t> CRemoteClientProtoDecode;
+	extern DetourHook<CRemoteClientManager_BroadcastAppStatus_t> CRemoteClientManager_BroadcastAppStatus;
+	extern DetourHook<CRemoteClientManager_UpdateRemoteAppState_t> CRemoteClientManager_UpdateRemoteAppState;
 
 	extern DetourHook<CSteamMatchmakingServers_GetServerDetails_t> CSteamMatchmakingServers_GetServerDetails;
 	extern DetourHook<CSteamMatchmakingServers_RequestInternetServerList_t> CSteamMatchmakingServers_RequestInternetServerList;

--- a/src/patterns.cpp
+++ b/src/patterns.cpp
@@ -78,6 +78,41 @@ namespace Patterns
 		};
 	}
 
+	namespace CRemoteClientManager
+	{
+		Pattern_t BroadcastAppStatus
+		{
+			"CRemoteClientManager::BroadcastAppStatus",
+			"8B 96 80 04 00 00 85 D2 0F 9F C0 84 C0 74 09 80 BE 12 06 00 00 00 74 24",
+			SigFollowMode::PrologueUpwards,
+			std::vector<int16_t> { 0x57, 0xE5, 0x89, 0x55 }
+		};
+
+		Pattern_t UpdateRemoteAppState
+		{
+			"CRemoteClientManager::UpdateRemoteAppState",
+			"8B 80 F4 00 00 00 89 FB EB 10",
+			SigFollowMode::PrologueUpwards,
+			std::vector<int16_t>
+			{
+				0x53, 0x56, 0x57, 0x55,
+				-1, -1, -1, -1, 0xC1, 0x81,
+				-1, -1, -1, -1, 0xE8
+			}
+		};
+	}
+
+	namespace CRemoteClient
+	{
+		Pattern_t DecodeAppStatus
+		{
+			"CRemoteClient::DecodeAppStatus",
+			"C6 46 0C 00 85 DB 0F 84 ? ? ? ? 8B 03 83 EC 0C 53 FF 50 14",
+			SigFollowMode::PrologueUpwards,
+			std::vector<int16_t> { 0x57, 0xE5, 0x89, 0x55 }
+		};
+	}
+
 	namespace CWebSocketConnection
 	{
 		Pattern_t BBuildAndAsyncSendFrame
@@ -202,4 +237,3 @@ namespace Patterns
 
 	std::vector<Pattern_t*> patterns;
 }
-

--- a/src/patterns.hpp
+++ b/src/patterns.hpp
@@ -40,6 +40,17 @@ namespace Patterns
 		extern Pattern_t BParseResponseMessage;
 	}
 
+	namespace CRemoteClient
+	{
+		extern Pattern_t DecodeAppStatus;
+	}
+
+	namespace CRemoteClientManager
+	{
+		extern Pattern_t BroadcastAppStatus;
+		extern Pattern_t UpdateRemoteAppState;
+	}
+
 	namespace CSteamEngine
 	{
 		extern Pattern_t GetServerPipe;


### PR DESCRIPTION
This fixes `AdditionalApps` not showing up on another device until Steam was restarted on the host.

With `SyncRemoteAdditionalApps` enabled, SLSsteam now picks up the remote app-status list, temporarily registers matching unowned apps on the receiving device, fetches their metadata, and asks Steam to send a fresh status after the host's config changes. It does not add anything to the receiving device's YAML.

I tested it from desktop Steam to a Steam Deck in Game Mode:

- all 9 existing test apps appeared on the Deck
- removing FISH³ on the desktop removed Stream on the Deck without restarting either device
- adding it back restored Stream without a restart
- adding a completely new game on the desktop also showed up on the Deck
- Steam's small one-app update packets no longer wipe the full remote list

Build checked with:

`DEBUG=1 make -j"$(nproc)" audit-libs`

This is disabled by default for now. The current cleanup logic is meant for one active host; multi-host tracking and immediate cleanup on disconnect can be handled separately.
